### PR TITLE
Variable name mismatch

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -90,7 +90,7 @@ end
 function FullLoot.makeRecords(pid)
     local cell = LoadedCells[tes3mp.GetCell(pid)]    
 
-    local name = string.format(FullLoot.config.guise.accountName, Players[pid].accountName)
+    local name = string.format(FullLoot.config.guise.name, Players[pid].accountName)
 
     --pick a random model
     local models = FullLoot.config.guise.models


### PR DESCRIPTION
The string FullLoot.config.guise.accountName doesn't exist, seems like FullLoot.config.guide.name was ment to be used.