### PR TITLE
change death hook to OnDeathTimeExpiration

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -241,7 +241,7 @@ end
 
 customEventHooks.registerHandler("OnServerPostInit", FullLoot.OnServerPostInit)
 customEventHooks.registerHandler("OnServerExit", FullLoot.OnServerExit)
-customEventHooks.registerValidator("OnPlayerDeath", FullLoot.OnPlayerDeathValidator)
+customEventHooks.registerValidator("OnDeathTimeExpiration", FullLoot.OnPlayerDeathValidator)
 
 customEventHooks.registerHandler("ContainerFramework_OnContainer", FullLoot.CFOnContainer)
 


### PR DESCRIPTION
For compatibility with kanaRevive https://github.com/Atkana/tes3mp-scripts/tree/master/0.7/kanaRevive

Grave will spawn when the player respawns, instead of when player health drops to 0.